### PR TITLE
Update run_noresm

### DIFF
--- a/run_noresm
+++ b/run_noresm
@@ -2,17 +2,15 @@ export CESM_PES=4
 
 sed -i -e "s/\$CESM_PES/$CESM_PES/g" /home/cesm/.cime/config_machines.xml
 
-cd /home/cesm/packages/noresm-dev
-
-sed -i.bak 's/# ARCHIVE COMMAND SIMILAR ACROSS ALL PLATFORMS/AR="$AR cq"/' cime/src/externals/mct/configure
+cd /home/cesm/packages/NorESM
 
 cd cime/scripts
 
-./create_newcase --case /home/cesm/cases/cN1850 --compset \
+./create_newcase --case /home/cesm/archive/cases/cN1850 --compset \
       1850_CAM60%NORESM_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV \
       --res f19_tn14 --machine espresso --run-unsupported 
       
-cd /home/cesm/cases/cN1850    
+cd /home/cesm/archive/cases/cN1850    
 
 # Change the number of nodes per component
 NUMNODES=-1
@@ -30,7 +28,3 @@ EOF
 # Build and run
 ./case.build
 ./case.submit
-
-mkdir -p /home/cesm/archive/cases
-
-cp -R /home/cesm/cases/cN1850 /home/cesm/archive/cases/.


### PR DESCRIPTION
Changed the name of the folder containing the source code (now to be obtained from https://github.com/NorESMhub/NorESM.git)
This version was already modified to cope with AR
Also changed the location of the case folder (now in archive)